### PR TITLE
add logrus tripperware

### DIFF
--- a/logging/logrus/DOC.md
+++ b/logging/logrus/DOC.md
@@ -34,13 +34,21 @@ func AsHttpLogger(logger *logrus.Entry) *log.Logger
 ```
 AsHttpLogger returns the given logrus instance as an HTTP logger.
 
-#### func  DefaultCodeToLevel
+#### func  DefaultMiddlewareCodeToLevel
 
 ```go
-func DefaultCodeToLevel(httpStatusCode int) logrus.Level
+func DefaultMiddlewareCodeToLevel(httpStatusCode int) logrus.Level
 ```
-DefaultCodeToLevel is the default implementation of gRPC return codes and
-interceptor log level.
+DefaultMiddlewareCodeToLevel is the default of a mapper between HTTP server-side
+status codes and logrus log levels.
+
+#### func  DefaultTripperwareCodeToLevel
+
+```go
+func DefaultTripperwareCodeToLevel(httpStatusCode int) logrus.Level
+```
+DefaultTripperwareCodeToLevel is the default of a mapper between HTTP
+client-side status codes and logrus log levels.
 
 #### func  Extract
 
@@ -69,9 +77,22 @@ This makes it safe to use regardless.
 #### func  Middleware
 
 ```go
-func Middleware(entry *logrus.Entry, opts ...Option) func(http.Handler) http.Handler
+func Middleware(entry *logrus.Entry, opts ...Option) httpwares.Middleware
 ```
 Middleware is a server-side http ware for logging using logrus.
+
+All handlers will have a Logrus logger in their context, which can be fetched
+using `http_logrus.Extract`.
+
+#### func  Tripperware
+
+```go
+func Tripperware(entry *logrus.Entry, opts ...Option) httpwares.Tripperware
+```
+Tripperware is a server-side http ware for logging using logrus.
+
+This tripperware *does not* propagate a context-based logger, but act as a
+logger of requests. This includes logging of errors.
 
 #### type CodeToLevel
 
@@ -89,10 +110,20 @@ type Option func(*options)
 ```
 
 
+#### func  WithConnectivityErrorLevel
+
+```go
+func WithConnectivityErrorLevel(level logrus.Level) Option
+```
+WithConnectivityErrorLevel customizes
+
 #### func  WithLevels
 
 ```go
 func WithLevels(f CodeToLevel) Option
 ```
-WithLevels customizes the function for mapping gRPC return codes and interceptor
-log level statements.
+WithLevels customizes the function that maps HTTP client or server side status
+codes to log levels.
+
+By default `DefaultMiddlewareCodeToLevel` is used for server-side middleware,
+and `DefaultTripperwareCodeToLevel` is used for client-side tripperware.

--- a/logging/logrus/tripperware.go
+++ b/logging/logrus/tripperware.go
@@ -1,0 +1,51 @@
+// Copyright 2017 Michal Witkowski. All Rights Reserved.
+// See LICENSE for licensing terms.
+
+package http_logrus
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/mwitkow/go-httpwares"
+	"github.com/mwitkow/go-httpwares/tags"
+)
+
+// Tripperware is a server-side http ware for logging using logrus.
+//
+// This tripperware *does not* propagate a context-based logger, but act as a logger of requests.
+// This includes logging of errors.
+func Tripperware(entry *logrus.Entry, opts ...Option) httpwares.Tripperware {
+	return func(next http.RoundTripper) http.RoundTripper {
+		o := evaluateTripperwareOpts(opts)
+		return httpwares.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			startTime := time.Now()
+			resp, err := next.RoundTrip(req)
+			fields := logrus.Fields{
+				"system":        SystemField,
+				"span.kind":     "client",
+				"http.url.path": req.URL.Path,
+				"http.time_ms":  timeDiffToMilliseconds(startTime),
+			}
+			for k, v := range http_ctxtags.ExtractOutbound(req).Values() {
+				fields[k] = v
+			}
+			level := logrus.DebugLevel
+			msg := "request completed"
+			if err != nil {
+				fields[logrus.ErrorKey] = err
+				level = o.levelForConnectivityError
+				msg = "request failed to execute, see err"
+			} else {
+				fields["http.proto_major"] = resp.ProtoMajor
+				fields["http.response_bytes"] = resp.ContentLength
+				fields["http.status"] = resp.StatusCode
+
+				level = o.levelFunc(resp.StatusCode)
+			}
+			levelLogf(entry.WithFields(fields), level, msg)
+			return resp, err
+		})
+	}
+}

--- a/logging/logrus/tripperware_test.go
+++ b/logging/logrus/tripperware_test.go
@@ -1,0 +1,146 @@
+// Copyright 2017 Michal Witkowski. All Rights Reserved.
+// See LICENSE for licensing terms.
+
+package http_logrus_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/mwitkow/go-httpwares"
+	"github.com/mwitkow/go-httpwares/logging/logrus"
+	"github.com/mwitkow/go-httpwares/tags"
+	"github.com/mwitkow/go-httpwares/testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+func customTripperwareCodeToLevel(statusCode int) logrus.Level {
+	if statusCode == testCodeImATeapot {
+		// Make this a special case for tests, and an error.
+		return logrus.ErrorLevel
+	}
+	level := http_logrus.DefaultTripperwareCodeToLevel(statusCode)
+	return level
+}
+
+func TestLogrusTripperwareSuite(t *testing.T) {
+	if strings.HasPrefix(runtime.Version(), "go1.7") {
+		t.Skipf("Skipping due to json.RawMessage incompatibility with go1.7")
+		return
+	}
+	b := &bytes.Buffer{}
+	log := logrus.New()
+	log.Out = b
+	log.Level = logrus.DebugLevel
+	log.Formatter = &logrus.JSONFormatter{DisableTimestamp: true}
+	s := &LogrusTripperwareSuite{
+		log:    logrus.NewEntry(log),
+		buffer: b,
+		WaresTestSuite: &httpwares_testing.WaresTestSuite{
+			Handler: &loggingHandler{t},
+			ClientTripperware: httpwares.TripperwareChain{
+				http_ctxtags.Tripperware(),
+				http_logrus.Tripperware(logrus.NewEntry(log), http_logrus.WithLevels(customTripperwareCodeToLevel)),
+			},
+		},
+	}
+	suite.Run(t, s)
+}
+
+type LogrusTripperwareSuite struct {
+	*httpwares_testing.WaresTestSuite
+	buffer *bytes.Buffer
+	log    *logrus.Entry
+}
+
+func (s *LogrusTripperwareSuite) SetupTest() {
+	s.buffer.Reset()
+}
+
+func (s *LogrusTripperwareSuite) getOutputJSONs() []string {
+	ret := []string{}
+	dec := json.NewDecoder(s.buffer)
+	for {
+		var val map[string]json.RawMessage
+		err := dec.Decode(&val)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			s.T().Fatalf("failed decoding output from Logrus JSON: %v", err)
+		}
+		out, _ := json.MarshalIndent(val, "", "  ")
+		ret = append(ret, string(out))
+	}
+	return ret
+}
+
+func (s *LogrusTripperwareSuite) TestSuccessfulCall() {
+	client := s.NewClient() // client always dials localhost.
+	req, _ := http.NewRequest("GET", "https://fakeaddress.fakeaddress.com/someurl", nil)
+	req = req.WithContext(s.SimpleCtx())
+	_, err := client.Do(req)
+	require.NoError(s.T(), err, "call shouldn't fail")
+	msgs := s.getOutputJSONs()
+	require.Len(s.T(), msgs, 1, "one log statements should be logged")
+	m := msgs[0]
+	s.T().Log(m)
+	assert.Contains(s.T(), m, `"span.kind": "client"`, "all lines must contain indicator of being a client call")
+	assert.Contains(s.T(), m, `"http.host": "fakeaddress.fakeaddress.com"`, "all lines must contain http.host from http_ctxtags")
+	assert.Contains(s.T(), m, `"http.url.path": "/someurl"`, "all lines must contain method name")
+	assert.Contains(s.T(), m, `"level": "debug"`, "warningf handler myst be logged as this..")
+	assert.Contains(s.T(), m, `"msg": "request completed"`, "interceptor message must contain string")
+	assert.Contains(s.T(), m, `"http.time_ms":`, "interceptor log statement should contain execution time")
+}
+
+func (s *LogrusTripperwareSuite) TestSuccessfulCall_WithRemap() {
+	for _, tcase := range []struct {
+		code  int
+		level logrus.Level
+		msg   string
+	}{
+		{
+			code:  http.StatusInternalServerError,
+			level: logrus.WarnLevel,
+			msg:   "Internal (500) must remap to WarnLevel in DefaultTripperwareCodeLevels",
+		},
+		{
+			code:  http.StatusNotFound,
+			level: logrus.InfoLevel,
+			msg:   "NotFound (404) must remap to InfoLevel in DefaultTripperwareCodeLevels",
+		},
+		{
+			code:  http.StatusBadRequest,
+			level: logrus.InfoLevel,
+			msg:   "BadRequest (400) must remap to InfoLevel in DefaultTripperwareCodeLevels",
+		},
+		{
+			code:  http.StatusTeapot,
+			level: logrus.ErrorLevel,
+			msg:   "ImATeapot is overwritten to ErrorLevel with customMiddlewareCodeToLevel override, which probably didn't work",
+		},
+	} {
+		s.buffer.Reset()
+		client := s.NewClient()
+		req, _ := http.NewRequest("GET", fmt.Sprintf("https://something.local/someurl?code=%d", tcase.code), nil)
+		req = req.WithContext(s.SimpleCtx())
+		_, err := client.Do(req)
+		require.NoError(s.T(), err, "call shouldn't fail")
+		msgs := s.getOutputJSONs()
+		require.Len(s.T(), msgs, 1, "only one message is logged")
+		m := msgs[0]
+		assert.Contains(s.T(), m, `"http.host": "something.local"`, "all lines must contain method name")
+		assert.Contains(s.T(), m, `"http.url.path": "/someurl"`, "all lines must contain method name")
+		assert.Contains(s.T(), m, fmt.Sprintf(`"http.status": %d`, tcase.code), "all lines must contain method name")
+		assert.Contains(s.T(), m, fmt.Sprintf(`"level": "%s"`, tcase.level.String()), tcase.msg)
+	}
+}

--- a/tracing/debug/tripperware.go
+++ b/tracing/debug/tripperware.go
@@ -40,7 +40,8 @@ func Tripperware(opts ...Option) httpwares.Tripperware {
 				tr.LazyPrintf("Error on response: %v", err)
 				tr.SetError()
 			} else {
-				tr.LazyPrintf("Response: %d, length: %d", resp.Status, resp.ContentLength)
+				tr.LazyPrintf("HTTP/%d.%d %d %s", resp.ProtoMajor, resp.ProtoMinor, resp.StatusCode, resp.StatusCode)
+				tr.LazyPrintf("Content-Length:  %d", resp.Status, resp.ContentLength)
 				for k, _ := range resp.Header {
 					tr.LazyPrintf("%v: %v", k, resp.Header.Get(k))
 				}


### PR DESCRIPTION
This adds a client-side middleware (Tripperware) for logging outbound requests to `http.Clients`.

@devnev @ains