### PR TITLE
Logrus Request/Response body capture Tripper/Middleware

### DIFF
--- a/logging/logrus/DOC.md
+++ b/logging/logrus/DOC.md
@@ -34,6 +34,44 @@ func AsHttpLogger(logger *logrus.Entry) *log.Logger
 ```
 AsHttpLogger returns the given logrus instance as an HTTP logger.
 
+#### func  ContentCaptureMiddleware
+
+```go
+func ContentCaptureMiddleware(entry *logrus.Entry, decider http_logging.ContentCaptureDeciderFunc) httpwares.Middleware
+```
+ContentCaptureMiddleware is a server-side http ware for logging contents of HTTP
+requests and responses (body and headers).
+
+Only requests with a set Content-Length will be captured, with no streaming or
+chunk encoding supported. Only responses with Content-Length set are captured,
+no gzipped, chunk-encoded responses are supported.
+
+The body will be recorded as a separate log message. Body of `application/json`
+will be captured as http.request.body_json (in structured JSON form) and others
+will be captured as http.request.body_raw logrus field (raw base64-encoded
+value).
+
+This *must* be used together with http_logrus.Middleware, as it relies on the
+logger provided there. However, you can override the `logrus.Entry` that is used
+for logging, allowing for logging to a separate backend (e.g. a different file).
+
+#### func  ContentCaptureTripperware
+
+```go
+func ContentCaptureTripperware(entry *logrus.Entry, decider http_logging.ContentCaptureDeciderFunc) httpwares.Tripperware
+```
+ContentCaptureTripperware is a client-side http ware for logging contents of
+HTTP requests and responses (body and headers).
+
+Only requests with a set GetBody field will be captured (strings, bytes etc).
+Only responses with Content-Length are captured, with no support for
+chunk-encoded responses.
+
+The body will be recorded as a separate log message. Body of `application/json`
+will be captured as http.request.body_json (in structured JSON form) and others
+will be captured as http.request.body_raw logrus field (raw base64-encoded
+value).
+
 #### func  DefaultMiddlewareCodeToLevel
 
 ```go

--- a/logging/logrus/DOC.md
+++ b/logging/logrus/DOC.md
@@ -100,8 +100,8 @@ logger of requests. This includes logging of errors.
 type CodeToLevel func(httpStatusCode int) logrus.Level
 ```
 
-CodeToLevel function defines the mapping between gRPC return codes and
-interceptor log level.
+CodeToLevel user functions define the mapping between HTTP status codes and
+logrus log levels.
 
 #### type Option
 
@@ -127,3 +127,40 @@ codes to log levels.
 
 By default `DefaultMiddlewareCodeToLevel` is used for server-side middleware,
 and `DefaultTripperwareCodeToLevel` is used for client-side tripperware.
+
+#### func  WithRequestBodyCapture
+
+```go
+func WithRequestBodyCapture(deciderFunc func(r *http.Request) bool) Option
+```
+WithRequestBodyCapture enables recording of request body pre-handling/pre-call.
+
+The body will be recorded as a separate log message. Body of `application/json`
+will be captured as http.request.body_json (in structured JSON form) and others
+will be captured as http.request.body_raw logrus field (raw base64-encoded
+value).
+
+For tripperware, only requests with Body of type `bytes.Buffer`,
+`strings.Reader`, `bytes.Buffer`, or with a specified `GetBody` function will be
+captured.
+
+For middleware, only requests with a set Content-Length will be captured, with
+no streaming or chunk encoding supported.
+
+This option creates a copy of the body per request, so please use with care.
+
+#### func  WithResponseBodyCapture
+
+```go
+func WithResponseBodyCapture(deciderFunc func(r *http.Request, status int) bool) Option
+```
+WithResponseBodyCapture enables recording of response body
+post-handling/post-call.
+
+The body will be recorded as a separate log message. Body of `application/json`
+will be captured as http.response.body_json (in structured JSON form) and others
+will be captured as http.response.body_raw logrus field (raw base64-encoded
+value).
+
+Only responses with Content-Length will be captured, with non-default
+Transfer-Encoding not being supported.

--- a/logging/logrus/capture_middleware.go
+++ b/logging/logrus/capture_middleware.go
@@ -1,0 +1,110 @@
+package http_logrus
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/mwitkow/go-httpwares"
+	"github.com/mwitkow/go-httpwares/logging"
+)
+
+// ContentCaptureMiddleware is a server-side http ware for logging contents of HTTP requests and responses (body and headers).
+//
+// Only requests with a set Content-Length will be captured, with no streaming or chunk encoding supported.
+// Only responses with Content-Length set are captured, no gzipped, chunk-encoded responses are supported.
+//
+// The body will be recorded as a separate log message. Body of `application/json` will be captured as
+// http.request.body_json (in structured JSON form) and others will be captured as http.request.body_raw logrus field
+// (raw base64-encoded value).
+//
+// This *must* be used together with http_logrus.Middleware, as it relies on the logger provided there. However, you can
+// override the `logrus.Entry` that is used for logging, allowing for logging to a separate backend (e.g. a different file).
+func ContentCaptureMiddleware(entry *logrus.Entry, decider http_logging.ContentCaptureDeciderFunc) httpwares.Middleware {
+	return func(nextHandler http.Handler) http.Handler {
+		return http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+			if !decider(req) {
+				nextHandler.ServeHTTP(resp, req)
+				return
+			}
+			logger := entry.WithFields(Extract(req).Data)
+			if err := captureMiddlewareRequestContent(req, logger); err != nil {
+				// this is *really* bad, we failed to read a body because of a read error.
+				resp.WriteHeader(500)
+				logger.WithError(err).Warningf("error in logrus middleware on body read")
+				return
+			}
+			wrappedResp := httpwares.WrapResponseWriter(resp)
+			responseCapture := captureMiddlewareResponseContent(wrappedResp, logger)
+			nextHandler.ServeHTTP(wrappedResp, req)
+			responseCapture.finish() // captureResponse has a nil check, this can be nil
+		})
+	}
+}
+
+func captureMiddlewareRequestContent(req *http.Request, entry *logrus.Entry) error {
+	if req.ContentLength <= 0 || req.Body == nil {
+		// -1 value means that the length cannot be determined, and that it is probably a multipart stremaing call
+		if req.ContentLength != 0 || req.Body == nil {
+			entry.Infof("request body capture skipped, content length negative")
+		}
+		return nil
+	}
+	content, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		return err
+	}
+	// Make sure we give the Response back its body so the client can read it.
+	req.Body = ioutil.NopCloser(bytes.NewReader(content))
+	if strings.HasPrefix(strings.ToLower(req.Header.Get("content-type")), "application/json") {
+		entry.WithField("http.request.body_json", json.RawMessage(content)).Info("request body captured in http.request.body_json field")
+	} else {
+		entry.WithField("http.request.body_raw", base64.StdEncoding.EncodeToString(content)).Info("request body captured in http.request.body_raw field")
+	}
+	return nil
+}
+
+type responseCapture struct {
+	content bytes.Buffer
+	isJson  bool
+	entry   *logrus.Entry
+}
+
+func (c *responseCapture) observeWrite(resp httpwares.WrappedResponseWriter, buf []byte, n int, err error) {
+	if err == nil {
+		c.content.Write(buf[:n])
+	}
+}
+
+func (c *responseCapture) finish() {
+	if c == nil {
+		return
+	}
+	if c.content.Len() == 0 {
+		return
+	}
+	if c.isJson {
+		e := c.entry.WithField("http.response.body_json", json.RawMessage(c.content.Bytes()))
+		e.Info("response body captured in http.response.body_json field")
+	} else {
+		e := c.entry.WithField("http.response.body_raw", base64.StdEncoding.EncodeToString(c.content.Bytes()))
+		e.Info("response body captured in http.response.body_raw field")
+	}
+}
+
+func captureMiddlewareResponseContent(w httpwares.WrappedResponseWriter, entry *logrus.Entry) *responseCapture {
+	c := &responseCapture{entry: entry}
+	w.ObserveWriteHeader(func(w httpwares.WrappedResponseWriter, code int) {
+		if te := w.Header().Get("transfer-encoding"); te != "" {
+			entry.Infof("response body capture skipped, transfer encoding is not identity")
+			return
+		}
+		c.isJson = headerIsJson(w.Header())
+		w.ObserveWrite(c.observeWrite)
+	})
+	return c
+}

--- a/logging/logrus/capture_test.go
+++ b/logging/logrus/capture_test.go
@@ -1,0 +1,140 @@
+// Copyright 2017 Michal Witkowski. All Rights Reserved.
+// See LICENSE for licensing terms.
+
+package http_logrus_test
+
+import (
+	"bytes"
+	"net/http"
+	"runtime"
+	"strings"
+	"testing"
+
+	"io/ioutil"
+
+	"io"
+	"mime/multipart"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/mwitkow/go-httpwares"
+	"github.com/mwitkow/go-httpwares/logging/logrus"
+	"github.com/mwitkow/go-httpwares/tags"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+var (
+	nullLogger = &logrus.Logger{
+		Out:       ioutil.Discard,
+		Formatter: new(logrus.TextFormatter),
+		Hooks:     make(logrus.LevelHooks),
+		Level:     logrus.PanicLevel,
+	}
+)
+
+func TestLogrusContentCaptureSuite(t *testing.T) {
+	if strings.HasPrefix(runtime.Version(), "go1.7") {
+		t.Skipf("Skipping due to json.RawMessage incompatibility with go1.7")
+		return
+	}
+	alwaysOnDecider := func(req *http.Request) bool { return true }
+
+	s := &logrusContentCaptureSuite{newLogrusBaseTestSuite(t)}
+	s.logrusBaseTestSuite.logger.Level = logrus.DebugLevel // most of our log statements are on debug level.
+	// In this suite we have all the Tripperware, but no Middleware.
+	s.WaresTestSuite.ServerMiddleware = []httpwares.Middleware{
+		http_ctxtags.Middleware("somegroup"),
+		http_logrus.Middleware(logrus.NewEntry(nullLogger)),
+		http_logrus.ContentCaptureMiddleware(logrus.NewEntry(s.logger), alwaysOnDecider),
+	}
+	s.WaresTestSuite.ClientTripperware = httpwares.TripperwareChain{
+		http_ctxtags.Tripperware(),
+		http_logrus.ContentCaptureTripperware(logrus.NewEntry(s.logger), alwaysOnDecider),
+	}
+	suite.Run(t, s)
+}
+
+type logrusContentCaptureSuite struct {
+	*logrusBaseTestSuite
+}
+
+func (s *logrusContentCaptureSuite) getServerAndClientLogs(req *http.Request, expectedServer int, expectedClient int) (server []string, client []string) {
+	c := s.NewClient()
+	newReq := req.WithContext(s.SimpleCtx())
+	_, err := c.Do(newReq)
+	require.NoError(s.T(), err, "call shouldn't fail")
+	msgs := s.getOutputJSONs()
+	require.Len(s.T(), msgs, expectedClient+expectedServer, "this call should result in a different number of log statments")
+	for _, m := range msgs {
+		assert.Contains(s.T(), m, `"http.host": "`+req.URL.Host+`"`, "all lines must contain http.host from http_ctxtags")
+		assert.Contains(s.T(), m, `"http.url.path": "`+req.URL.Path+`"`, "all lines must contain method name")
+		assert.Contains(s.T(), m, `"level": "info"`, "body captures captures should be logged as info")
+		if strings.Contains(m, `"span.kind": "server"`) {
+			server = append(server, m)
+		} else if strings.Contains(m, `"span.kind": "client"`) {
+			client = append(client, m)
+		} else {
+			assert.Fail(s.T(), "message %v has no span kind", m)
+		}
+	}
+	return server, client
+}
+
+func (s *logrusContentCaptureSuite) TestCapture_SimpleJSONBothWays() {
+	content := new(bytes.Buffer)
+	content.WriteString(`{"somekey": "some_value", "someint": 4}`)
+	req, _ := http.NewRequest("POST", "https://fakeaddress.fakeaddress.com/capture/request/json", content)
+	req.Header.Set("content-type", "application/JSON")
+	serverMsgs, clientMsgs := s.getServerAndClientLogs(req, 2, 2)
+	assert.Contains(s.T(), clientMsgs[0], `"http.request.body_json": {`, "request capture should log messages as structued json")
+	assert.Contains(s.T(), serverMsgs[0], `"http.request.body_json": {`, "request capture should log messages as structued json")
+	assert.Contains(s.T(), clientMsgs[1], `"http.response.body_json": {`, "response capture should log messages as structued json")
+	assert.Contains(s.T(), serverMsgs[1], `"http.response.body_json": {`, "response capture should log messages as structued json")
+}
+
+func (s *logrusContentCaptureSuite) TestCapture_PlainTextBothWays() {
+	content := new(bytes.Buffer)
+	content.WriteString(`Lorem Ipsum, who cares?`)
+	req, _ := http.NewRequest("POST", "https://fakeaddress.fakeaddress.com/capture/request/plain", content)
+	req.Header.Set("content-type", "text/plain")
+	serverMsgs, clientMsgs := s.getServerAndClientLogs(req, 2, 2)
+	assert.Contains(s.T(), clientMsgs[0], `"http.request.body_raw": "`, "request capture should log messages as strings")
+	assert.Contains(s.T(), serverMsgs[0], `"http.request.body_raw": "`, "request capture should log messages as strings")
+	assert.Contains(s.T(), clientMsgs[1], `"http.response.body_raw": "`, "response capture should log messages as strings")
+	assert.Contains(s.T(), serverMsgs[1], `"http.response.body_raw": "`, "response capture should log messages as strings")
+}
+
+func (s *logrusContentCaptureSuite) TestCapture_StreamFileUp() {
+	// Make a request that simulates a file upload.
+	reader, writer := io.Pipe()
+	multipartContent := multipart.NewWriter(writer)
+	go func() {
+		mimeWriter, _ := multipartContent.CreateFormFile("somefield", "filename.txt")
+		for i := 0; i < 10; i++ {
+			mimeWriter.Write([]byte("something\n"))
+		}
+		multipartContent.Close()
+		writer.Close()
+	}()
+
+	req, _ := http.NewRequest("POST", "https://fakeaddress.fakeaddress.com/capture/request/json", reader)
+	req.Header.Set("content-type", multipartContent.FormDataContentType())
+	serverMsgs, clientMsgs := s.getServerAndClientLogs(req, 2, 2)
+	assert.Contains(s.T(), clientMsgs[0], `request body capture skipped, missing GetBody method while Body set`, "request should log a helpful error")
+	assert.Contains(s.T(), serverMsgs[0], `request body capture skipped, content length negative`, "request should log a helpful error")
+	assert.Contains(s.T(), clientMsgs[1], `"http.response.body_json": {`, "response capture should log pingback response as JSON")
+	assert.Contains(s.T(), serverMsgs[1], `"http.response.body_json": {`, "response capture should log pingback response as JSON")
+}
+
+func (s *logrusContentCaptureSuite) TestCapture_ChunkResponse() {
+	content := new(bytes.Buffer)
+	content.WriteString(`{"somekey": "some_value", "someint": 4}`)
+	req, _ := http.NewRequest("POST", "https://fakeaddress.fakeaddress.com/capture/request/chunked", content)
+	req.Header.Set("content-type", "application/JSON")
+	serverMsgs, clientMsgs := s.getServerAndClientLogs(req, 2, 2)
+	assert.Contains(s.T(), clientMsgs[0], `"http.request.body_json": {`, "request capture should log messages as structued json")
+	assert.Contains(s.T(), serverMsgs[0], `"http.request.body_json": {`, "request capture should log messages as structued json")
+	assert.Contains(s.T(), clientMsgs[1], `"response body capture skipped, content length negative"`, "client side should log a helpful message")
+	assert.Contains(s.T(), serverMsgs[1], `"response body capture skipped, transfer encoding is not identity"`, "server side should log a helpful message about skipped body")
+}

--- a/logging/logrus/capture_tripperware.go
+++ b/logging/logrus/capture_tripperware.go
@@ -1,0 +1,95 @@
+package http_logrus
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/mwitkow/go-httpwares"
+	"github.com/mwitkow/go-httpwares/logging"
+)
+
+// ContentCaptureTripperware is a client-side http ware for logging contents of HTTP requests and responses (body and headers).
+//
+// Only requests with a set GetBody field will be captured (strings, bytes etc).
+// Only responses with Content-Length are captured, with no support for chunk-encoded responses.
+//
+// The body will be recorded as a separate log message. Body of `application/json` will be captured as
+// http.request.body_json (in structured JSON form) and others will be captured as http.request.body_raw logrus field
+// (raw base64-encoded value).
+func ContentCaptureTripperware(entry *logrus.Entry, decider http_logging.ContentCaptureDeciderFunc) httpwares.Tripperware {
+	return func(next http.RoundTripper) http.RoundTripper {
+		return httpwares.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			if !decider(req) {
+				return next.RoundTrip(req)
+			}
+			fields := newClientRequestFields(req)
+			if err := captureTripperwareRequestContent(req, entry.WithFields(fields)); err != nil {
+				return nil, err // errors reading GetBody and other problems on client side
+			}
+			resp, err := next.RoundTrip(req)
+			if err != nil {
+				return nil, err
+			}
+			if err := captureTripperwareResponseContent(resp, entry.WithFields(fields)); err != nil {
+				return nil, err
+			}
+			return resp, nil
+		})
+	}
+}
+
+func headerIsJson(header http.Header) bool {
+	return strings.HasPrefix(strings.ToLower(header.Get("content-type")), "application/json")
+}
+
+func captureTripperwareRequestContent(req *http.Request, entry *logrus.Entry) error {
+	// All requests created with http.NewRequest will have a GetBody method set, even if the user created
+	// a body manually.
+	if req.GetBody == nil {
+		if req.Body != nil {
+			entry.Infof("request body capture skipped, missing GetBody method while Body set")
+		}
+		return nil
+	}
+	bodyReader, err := req.GetBody()
+	if err != nil {
+		return err
+	}
+	content, err := ioutil.ReadAll(bodyReader)
+	if err != nil {
+		return err
+	}
+	if headerIsJson(req.Header) {
+		entry.WithField("http.request.body_json", json.RawMessage(content)).Info("request body captured in http.request.body_json field")
+	} else {
+		entry.WithField("http.request.body_raw", base64.StdEncoding.EncodeToString(content)).Info("request body captured in http.request.body_raw field")
+	}
+	return nil
+}
+
+func captureTripperwareResponseContent(resp *http.Response, entry *logrus.Entry) error {
+	if resp.ContentLength <= 0 {
+		// TODO(mwitkow): Deal with response.Uncompressed and gzip encoding (Content Length -1).
+		if resp.ContentLength != 0 {
+			entry.Infof("response body capture skipped, content length negative")
+		}
+		return nil
+	}
+	content, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err // this is an error form the response reading, potentially a connection failure
+	}
+	// Make sure we give the Response back its body so the client can read it.
+	resp.Body = ioutil.NopCloser(bytes.NewReader(content))
+	if headerIsJson(resp.Header) {
+		entry.WithField("http.response.body_json", json.RawMessage(content)).Info("request body captured in http.response.body_json field")
+	} else {
+		entry.WithField("http.response.body_raw", base64.StdEncoding.EncodeToString(content)).Info("request body captured in http.response.body_raw field")
+	}
+	return nil
+}

--- a/logging/logrus/middleware.go
+++ b/logging/logrus/middleware.go
@@ -4,13 +4,17 @@
 package http_logrus
 
 import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"io/ioutil"
+	"strings"
 	"time"
 
 	"net/http"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/mwitkow/go-httpwares"
-	"golang.org/x/net/context"
 )
 
 var (
@@ -26,32 +30,44 @@ func Middleware(entry *logrus.Entry, opts ...Option) httpwares.Middleware {
 		o := evaluateMiddlewareOpts(opts)
 		return http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 			wrappedResp := httpwares.WrapResponseWriter(resp)
-			nCtx := newContextLogger(req.Context(), entry, req)
+			newEntry := entry.WithFields(
+				logrus.Fields{
+					"system":                    SystemField,
+					"span.kind":                 "server",
+					"http.url.path":             req.URL.Path,
+					"http.proto_major":          req.ProtoMajor,
+					"http.request.length_bytes": req.ContentLength,
+				})
+			newReq := req.WithContext(toContext(req.Context(), newEntry))
+			if o.requestCaptureFunc(req) {
+				if err := captureMiddlewareRequestContent(req, Extract(newReq)); err != nil {
+					// this is *really* bad, we failed to read a body because of a read error.
+					resp.WriteHeader(500)
+					Extract(newReq).WithError(err).Warningf("error in logrus middleware on body read")
+					return
+				}
+			}
+			var capture *responseCapture
+			wrappedResp.ObserveWriteHeader(func(w httpwares.WrappedResponseWriter, code int) {
+				if o.responseCaptureFunc(req, code) {
+					capture = captureMiddlewareResponseContent(w, Extract(newReq))
+				}
+			})
 			startTime := time.Now()
-			nextHandler.ServeHTTP(wrappedResp, req.WithContext(nCtx))
+			nextHandler.ServeHTTP(wrappedResp, newReq)
+			capture.finish() // captureResponse has a nil check, this can be nil
+
 			postCallFields := logrus.Fields{
 				"http.status":  wrappedResp.StatusCode(),
 				"http.time_ms": timeDiffToMilliseconds(startTime),
 			}
 			level := o.levelFunc(wrappedResp.StatusCode())
 			levelLogf(
-				ExtractFromContext(nCtx).WithFields(postCallFields), // re-extract logger from newCtx, as it may have extra fields that changed in the holder.
+				Extract(newReq).WithFields(postCallFields), // re-extract logger from newCtx, as it may have extra fields that changed in the holder.
 				level,
 				"handled")
 		})
 	}
-}
-
-func newContextLogger(ctx context.Context, entry *logrus.Entry, r *http.Request) context.Context {
-	callLog := entry.WithFields(
-		logrus.Fields{
-			"system":                    SystemField,
-			"span.kind":                 "server",
-			"http.url.path":             r.URL.Path,
-			"http.proto_major":          r.ProtoMajor,
-			"http.request.length_bytes": r.ContentLength,
-		})
-	return toContext(ctx, callLog)
 }
 
 func levelLogf(entry *logrus.Entry, level logrus.Level, format string, args ...interface{}) {
@@ -80,4 +96,65 @@ func timeDiffToMilliseconds(then time.Time) float32 {
 		return 0.0
 	}
 	return float32(sub/1000) / 1000.0
+}
+
+func captureMiddlewareRequestContent(req *http.Request, entry *logrus.Entry) error {
+	if req.ContentLength <= 0 || req.Body == nil {
+		// -1 value means that the length cannot be determined, and that it is probably a multipart stremaing call
+		if req.ContentLength != 0 || req.Body == nil {
+			entry.Infof("request body capture skipped, content length negative")
+		}
+		return nil
+	}
+	content, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		return err
+	}
+	// Make sure we give the Response back its body so the client can read it.
+	req.Body = ioutil.NopCloser(bytes.NewReader(content))
+	if strings.HasPrefix(strings.ToLower(req.Header.Get("content-type")), "application/json") {
+		entry.WithField("http.request.body_json", json.RawMessage(content)).Info("request body captured in http.request.body_json field")
+	} else {
+		entry.WithField("http.request.body_raw", base64.StdEncoding.EncodeToString(content)).Info("request body captured in http.request.body_raw field")
+	}
+	return nil
+}
+
+type responseCapture struct {
+	content bytes.Buffer
+	isJson  bool
+	entry   *logrus.Entry
+}
+
+func (c *responseCapture) observeWrite(resp httpwares.WrappedResponseWriter, buf []byte, n int, err error) {
+	if err == nil {
+		c.content.Write(buf[:n])
+	}
+}
+
+func (c *responseCapture) finish() {
+	if c == nil {
+		return
+	}
+	if c.content.Len() == 0 {
+		return
+	}
+	if c.isJson {
+		e := c.entry.WithField("http.response.body_json", json.RawMessage(c.content.Bytes()))
+		e.Info("response body captured in http.response.body_json field")
+	} else {
+		e := c.entry.WithField("http.response.body_raw", base64.StdEncoding.EncodeToString(c.content.Bytes()))
+		e.Info("response body captured in http.response.body_raw field")
+	}
+}
+
+func captureMiddlewareResponseContent(w httpwares.WrappedResponseWriter, entry *logrus.Entry) *responseCapture {
+	c := &responseCapture{entry: entry}
+	if te := w.Header().Get("transfer-encoding"); te != "" {
+		entry.Infof("response body capture skipped, transfer encoding is not identity")
+		return nil
+	}
+	c.isJson = headerIsJson(w.Header())
+	w.ObserveWrite(c.observeWrite)
+	return c
 }

--- a/logging/logrus/middleware_test.go
+++ b/logging/logrus/middleware_test.go
@@ -13,12 +13,14 @@ import (
 	"strings"
 	"testing"
 
+	"mime/multipart"
+	"time"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/mwitkow/go-httpwares"
 	"github.com/mwitkow/go-httpwares/logging/logrus"
 	"github.com/mwitkow/go-httpwares/tags"
 	"github.com/mwitkow/go-httpwares/testing"
-	"github.com/opentracing/opentracing-go/mocktracer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -39,15 +41,6 @@ func (a *loggingHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) 
 	httpwares_testing.PingBackHandler(httpwares_testing.DefaultPingBackStatusCode).ServeHTTP(resp, req)
 }
 
-type LogrusLoggingTestSuite struct {
-	*httpwares_testing.WaresTestSuite
-	mockTracer *mocktracer.MockTracer
-}
-
-func (s *LogrusLoggingTestSuite) SetupTest() {
-	s.mockTracer.Reset()
-}
-
 func customMiddlewareCodeToLevel(statusCode int) logrus.Level {
 	if statusCode == testCodeImATeapot {
 		// Make this a special case for tests, and an error.
@@ -57,7 +50,7 @@ func customMiddlewareCodeToLevel(statusCode int) logrus.Level {
 	return level
 }
 
-func TestLogrusLoggingSuite(t *testing.T) {
+func TestLogrusMiddlewareSuite(t *testing.T) {
 	if strings.HasPrefix(runtime.Version(), "go1.7") {
 		t.Skipf("Skipping due to json.RawMessage incompatibility with go1.7")
 		return
@@ -66,31 +59,42 @@ func TestLogrusLoggingSuite(t *testing.T) {
 	log := logrus.New()
 	log.Out = b
 	log.Formatter = &logrus.JSONFormatter{DisableTimestamp: true}
-	s := &LogrusLoggingSuite{
+	s := &LogrusMiddlewareSuite{
 		log:    logrus.NewEntry(log),
 		buffer: b,
 		WaresTestSuite: &httpwares_testing.WaresTestSuite{
-			Handler: &loggingHandler{t},
+			Handler: handlerForTestingOfCaptures(t),
 			ServerMiddleware: []httpwares.Middleware{
 				http_ctxtags.Middleware("my_service"),
-				http_logrus.Middleware(logrus.NewEntry(log), http_logrus.WithLevels(customMiddlewareCodeToLevel)),
+				http_logrus.Middleware(
+					logrus.NewEntry(log),
+					http_logrus.WithLevels(customMiddlewareCodeToLevel),
+					http_logrus.WithRequestBodyCapture(requestCaptureDeciderForTest),
+					http_logrus.WithResponseBodyCapture(responseCaptureDeciderForTest),
+				),
 			},
 		},
 	}
 	suite.Run(t, s)
 }
 
-type LogrusLoggingSuite struct {
+type LogrusMiddlewareSuite struct {
 	*httpwares_testing.WaresTestSuite
 	buffer *bytes.Buffer
 	log    *logrus.Entry
 }
 
-func (s *LogrusLoggingSuite) SetupTest() {
+func (s *LogrusMiddlewareSuite) SetupTest() {
 	s.buffer.Reset()
 }
 
-func (s *LogrusLoggingSuite) getOutputJSONs() []string {
+func (s *LogrusMiddlewareSuite) TearDownTest() {
+	s.buffer.Reset()
+}
+
+func (s *LogrusMiddlewareSuite) getOutputJSONs() []string {
+	// So the final `handled` method may happen after the client completed the response. So wait here.
+	time.Sleep(50 * time.Millisecond)
 	ret := []string{}
 	dec := json.NewDecoder(s.buffer)
 	for {
@@ -108,7 +112,7 @@ func (s *LogrusLoggingSuite) getOutputJSONs() []string {
 	return ret
 }
 
-func (s *LogrusLoggingSuite) TestPing_WithCustomTags() {
+func (s *LogrusMiddlewareSuite) TestPing_WithCustomTags() {
 	client := s.NewClient()
 	req, _ := http.NewRequest("GET", "https://something.local/someurl", nil)
 	req = req.WithContext(s.SimpleCtx())
@@ -130,7 +134,7 @@ func (s *LogrusLoggingSuite) TestPing_WithCustomTags() {
 	assert.Contains(s.T(), msgs[1], `"http.time_ms":`, "interceptor log statement should contain execution time")
 }
 
-func (s *LogrusLoggingSuite) TestPingError_WithCustomLevels() {
+func (s *LogrusMiddlewareSuite) TestPingError_WithCustomLevels() {
 	for _, tcase := range []struct {
 		code  int
 		level logrus.Level
@@ -171,4 +175,113 @@ func (s *LogrusLoggingSuite) TestPingError_WithCustomLevels() {
 		assert.Contains(s.T(), m, fmt.Sprintf(`"http.status": %d`, tcase.code), "all lines must contain method name")
 		assert.Contains(s.T(), m, fmt.Sprintf(`"level": "%s"`, tcase.level.String()), tcase.msg)
 	}
+}
+
+func (s *LogrusMiddlewareSuite) TestCapture_SimpleJSONBothWays() {
+	client := s.NewClient() // client always dials localhost.
+	content := new(bytes.Buffer)
+	content.WriteString(`{"somekey": "some_value", "someint": 4}`)
+	req, _ := http.NewRequest("POST", "https://fakeaddress.fakeaddress.com/capture/request/json", content)
+	req = req.WithContext(s.SimpleCtx())
+	req.Header.Set("content-type", "application/JSON")
+	resp, err := client.Do(req)
+	require.NoError(s.T(), err, "call shouldn't fail")
+	pingBack, err := httpwares_testing.DecodePingBack(resp)
+	require.NoError(s.T(), err, "decoding pingback response must not fail, otherwise we change the behaviour of the client")
+	assert.Equal(s.T(), "application/JSON", pingBack.Headers["Content-Type"], "the content must be preserved")
+
+	msgs := s.getOutputJSONs()
+	require.Len(s.T(), msgs, 4, "three log statements should be logged: captured req, handler, captured resp, and final one")
+	for _, m := range msgs {
+		assert.Contains(s.T(), m, `"span.kind": "server"`, "all lines must contain indicator of being a server call")
+		assert.Contains(s.T(), m, `"http.host": "fakeaddress.fakeaddress.com"`, "all lines must contain http.host from http_ctxtags")
+		assert.Contains(s.T(), m, `"http.url.path": "/capture/request/json"`, "all lines must contain method name")
+	}
+	reqMsg, respMsg, finalMsg := msgs[0], msgs[2], msgs[3]
+	assert.Contains(s.T(), reqMsg, `"level": "info"`, "request captures should be logged as info")
+	assert.Contains(s.T(), respMsg, `"level": "info"`, "response captures should be logged as info")
+	assert.Contains(s.T(), reqMsg, `"http.request.body_json": {`, "request capture should log messages as structued json")
+	assert.Contains(s.T(), respMsg, `"http.response.body_json": {`, "response capture should log messages as structued json")
+	assert.Contains(s.T(), finalMsg, `"http.time_ms":`, "interceptor log statement should contain execution time")
+}
+
+func (s *LogrusMiddlewareSuite) TestCapture_PlainTextBothWays() {
+	client := s.NewClient() // client always dials localhost.
+	content := new(bytes.Buffer)
+	content.WriteString(`Lorem Ipsum, who cares?`)
+	req, _ := http.NewRequest("POST", "https://fakeaddress.fakeaddress.com/capture/request/plain", content)
+	req = req.WithContext(s.SimpleCtx())
+	req.Header.Set("content-type", "text/plain")
+	_, err := client.Do(req)
+	require.NoError(s.T(), err, "call shouldn't fail")
+	msgs := s.getOutputJSONs()
+	require.Len(s.T(), msgs, 3, "three log statements should be logged: captured req, captured resp, and final one")
+	for _, m := range msgs {
+		assert.Contains(s.T(), m, `"span.kind": "server"`, "all lines must contain indicator of being a server call")
+		assert.Contains(s.T(), m, `"http.host": "fakeaddress.fakeaddress.com"`, "all lines must contain http.host from http_ctxtags")
+		assert.Contains(s.T(), m, `"http.url.path": "/capture/request/plain"`, "all lines must contain method name")
+	}
+	reqMsg, respMsg, finalMsg := msgs[0], msgs[1], msgs[2]
+
+	assert.Contains(s.T(), reqMsg, `"level": "info"`, "request captures should be logged as info")
+	assert.Contains(s.T(), respMsg, `"level": "info"`, "response captures should be logged as info")
+	assert.Contains(s.T(), reqMsg, `"http.request.body_raw": "`, "request capture should log messages as strings")
+	assert.Contains(s.T(), respMsg, `"http.response.body_raw": "`, "response capture should log messages as strings")
+	assert.Contains(s.T(), finalMsg, `"http.time_ms":`, "interceptor log statement should contain execution time")
+}
+
+func (s *LogrusMiddlewareSuite) TestCapture_ChunkResponse() {
+	client := s.NewClient() // client always dials localhost.
+	content := new(bytes.Buffer)
+	content.WriteString(`{"somekey": "some_value", "someint": 4}`)
+	req, _ := http.NewRequest("POST", "https://fakeaddress.fakeaddress.com/capture/request/chunked", content)
+	req = req.WithContext(s.SimpleCtx())
+	req.Header.Set("content-type", "application/JSON")
+	_, err := client.Do(req)
+	require.NoError(s.T(), err, "call shouldn't fail")
+	msgs := s.getOutputJSONs()
+	require.Len(s.T(), msgs, 3, "three log statements should be logged: captured req, captured resp, and final one")
+	for _, m := range msgs {
+		assert.Contains(s.T(), m, `"span.kind": "server"`, "all lines must contain indicator of being a server call")
+		assert.Contains(s.T(), m, `"http.host": "fakeaddress.fakeaddress.com"`, "all lines must contain http.host from http_ctxtags")
+		assert.Contains(s.T(), m, `"http.url.path": "/capture/request/chunked"`, "all lines must contain method name")
+	}
+	respMsg, finalMsg := msgs[1], msgs[2]
+	assert.Contains(s.T(), respMsg, `"level": "info"`, "response captures should be logged as info")
+	assert.Contains(s.T(), respMsg, `response body capture skipped, transfer encoding is not identity`, "response capture should log a helpful message")
+	assert.Contains(s.T(), finalMsg, `"http.time_ms":`, "interceptor log statement should contain execution time")
+}
+
+func (s *LogrusMiddlewareSuite) TestCapture_StreamFileUp() {
+	client := s.NewClient() // client always dials localhost.
+	reader, writer := io.Pipe()
+	multipartContent := multipart.NewWriter(writer)
+	go func() {
+		mimeWriter, _ := multipartContent.CreateFormFile("somefield", "filename.txt")
+		for i := 0; i < 10; i++ {
+			mimeWriter.Write([]byte("something\n"))
+		}
+		multipartContent.Close()
+		writer.Close()
+	}()
+	req, _ := http.NewRequest("POST", "https://fakeaddress.fakeaddress.com/capture/request/json", reader)
+	req.Header.Set("content-type", multipartContent.FormDataContentType())
+	req = req.WithContext(s.SimpleCtx())
+	resp, err := client.Do(req)
+	pingBack, err := httpwares_testing.DecodePingBack(resp)
+	require.NoError(s.T(), err, "decoding pingback response must not fail, otherwise we change the behaviour of the client")
+	assert.Contains(s.T(), pingBack.Headers["Content-Type"], "multipart/form-data", "the content must be preserved")
+
+	require.NoError(s.T(), err, "call shouldn't fail")
+	msgs := s.getOutputJSONs()
+	require.Len(s.T(), msgs, 4, "three log statements should be logged: captured req, captured resp, handler, and final one")
+	for _, m := range msgs {
+		assert.Contains(s.T(), m, `"span.kind": "server"`, "all lines must contain indicator of being a server call")
+		assert.Contains(s.T(), m, `"http.host": "fakeaddress.fakeaddress.com"`, "all lines must contain http.host from http_ctxtags")
+		assert.Contains(s.T(), m, `"http.url.path": "/capture/request/json"`, "all lines must contain method name")
+	}
+	reqMsg, finalMsg := msgs[0], msgs[3]
+	assert.Contains(s.T(), reqMsg, `"level": "info"`, "request captures should be logged as info")
+	assert.Contains(s.T(), reqMsg, `request body capture skipped, content length negative`, "request should log a helpful error")
+	assert.Contains(s.T(), finalMsg, `"http.time_ms":`, "interceptor log statement should contain execution time")
 }

--- a/logging/logrus/middleware_test.go
+++ b/logging/logrus/middleware_test.go
@@ -4,15 +4,11 @@
 package http_logrus_test
 
 import (
-	"bytes"
 	"fmt"
-	"io"
 	"net/http"
 	"runtime"
 	"strings"
 	"testing"
-
-	"mime/multipart"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/mwitkow/go-httpwares"
@@ -104,69 +100,4 @@ func (s *logrusMiddlewareTestSuite) TestPingError_WithCustomLevels() {
 		assert.Contains(s.T(), m, fmt.Sprintf(`"http.status": %d`, tcase.code), "all lines must contain method name")
 		assert.Contains(s.T(), m, fmt.Sprintf(`"level": "%s"`, tcase.level.String()), tcase.msg)
 	}
-}
-
-func (s *logrusMiddlewareTestSuite) TestCapture_SimpleJSONBothWays() {
-	content := new(bytes.Buffer)
-	content.WriteString(`{"somekey": "some_value", "someint": 4}`)
-	req, _ := http.NewRequest("POST", "https://fakeaddress.fakeaddress.com/capture/request/json", content)
-	req.Header.Set("content-type", "Application/JSON")
-	msgs := s.makeSuccessfulRequestWithAssertions(req, 4, "server")
-
-	reqMsg, respMsg, finalMsg := msgs[0], msgs[2], msgs[3]
-	assert.Contains(s.T(), reqMsg, `"level": "info"`, "request captures should be logged as info")
-	assert.Contains(s.T(), respMsg, `"level": "info"`, "response captures should be logged as info")
-	assert.Contains(s.T(), reqMsg, `"http.request.body_json": {`, "request capture should log messages as structued json")
-	assert.Contains(s.T(), respMsg, `"http.response.body_json": {`, "response capture should log messages as structued json")
-	assert.Contains(s.T(), finalMsg, `"http.time_ms":`, "interceptor log statement should contain execution time")
-}
-
-func (s *logrusMiddlewareTestSuite) TestCapture_PlainTextBothWays() {
-	content := new(bytes.Buffer)
-	content.WriteString(`Lorem Ipsum, who cares?`)
-	req, _ := http.NewRequest("POST", "https://fakeaddress.fakeaddress.com/capture/request/plain", content)
-	req.Header.Set("content-type", "text/plain")
-	msgs := s.makeSuccessfulRequestWithAssertions(req, 3, "server")
-
-	reqMsg, respMsg, finalMsg := msgs[0], msgs[1], msgs[2]
-	assert.Contains(s.T(), reqMsg, `"level": "info"`, "request captures should be logged as info")
-	assert.Contains(s.T(), respMsg, `"level": "info"`, "response captures should be logged as info")
-	assert.Contains(s.T(), reqMsg, `"http.request.body_raw": "`, "request capture should log messages as strings")
-	assert.Contains(s.T(), respMsg, `"http.response.body_raw": "`, "response capture should log messages as strings")
-	assert.Contains(s.T(), finalMsg, `"http.time_ms":`, "interceptor log statement should contain execution time")
-}
-
-func (s *logrusMiddlewareTestSuite) TestCapture_ChunkResponse() {
-	content := new(bytes.Buffer)
-	content.WriteString(`{"somekey": "some_value", "someint": 4}`)
-	req, _ := http.NewRequest("POST", "https://fakeaddress.fakeaddress.com/capture/request/chunked", content)
-	req.Header.Set("content-type", "application/json")
-	msgs := s.makeSuccessfulRequestWithAssertions(req, 3, "server")
-
-	respMsg, finalMsg := msgs[1], msgs[2]
-	assert.Contains(s.T(), respMsg, `"level": "info"`, "response captures should be logged as info")
-	assert.Contains(s.T(), respMsg, `response body capture skipped, transfer encoding is not identity`, "response capture should log a helpful message")
-	assert.Contains(s.T(), finalMsg, `"http.time_ms":`, "interceptor log statement should contain execution time")
-}
-
-func (s *logrusMiddlewareTestSuite) TestCapture_StreamFileUp() {
-	// Simulate an async upload of a file.
-	reader, writer := io.Pipe()
-	multipartContent := multipart.NewWriter(writer)
-	go func() {
-		mimeWriter, _ := multipartContent.CreateFormFile("somefield", "filename.txt")
-		for i := 0; i < 10; i++ {
-			mimeWriter.Write([]byte("something\n"))
-		}
-		multipartContent.Close()
-		writer.Close()
-	}()
-	req, _ := http.NewRequest("POST", "https://fakeaddress.fakeaddress.com/capture/request/json", reader)
-	req.Header.Set("content-type", multipartContent.FormDataContentType())
-	msgs := s.makeSuccessfulRequestWithAssertions(req, 4, "server")
-
-	reqMsg, finalMsg := msgs[0], msgs[3]
-	assert.Contains(s.T(), reqMsg, `"level": "info"`, "request captures should be logged as info")
-	assert.Contains(s.T(), reqMsg, `request body capture skipped, content length negative`, "request should log a helpful error")
-	assert.Contains(s.T(), finalMsg, `"http.time_ms":`, "interceptor log statement should contain execution time")
 }

--- a/logging/logrus/options.go
+++ b/logging/logrus/options.go
@@ -25,29 +25,24 @@ type options struct {
 	responseCaptureFunc       func(r *http.Request, status int) bool
 }
 
-func evaluateOptions(opts []Option) *options {
+func evaluateTripperwareOpts(opts []Option) *options {
 	optCopy := &options{}
 	*optCopy = *defaultOptions
+	optCopy.levelFunc = DefaultTripperwareCodeToLevel
 	for _, o := range opts {
 		o(optCopy)
 	}
 	return optCopy
 }
 
-func evaluateTripperwareOpts(opts []Option) *options {
-	o := evaluateOptions(opts)
-	if o.levelFunc == nil {
-		o.levelFunc = DefaultTripperwareCodeToLevel
-	}
-	return o
-}
-
 func evaluateMiddlewareOpts(opts []Option) *options {
-	o := evaluateOptions(opts)
-	if o.levelFunc == nil {
-		o.levelFunc = DefaultMiddlewareCodeToLevel
+	optCopy := &options{}
+	*optCopy = *defaultOptions
+	optCopy.levelFunc = DefaultMiddlewareCodeToLevel
+	for _, o := range opts {
+		o(optCopy)
 	}
-	return o
+	return optCopy
 }
 
 type Option func(*options)

--- a/logging/logrus/options.go
+++ b/logging/logrus/options.go
@@ -13,12 +13,16 @@ var (
 	defaultOptions = &options{
 		levelFunc:                 nil,
 		levelForConnectivityError: logrus.WarnLevel,
+		requestCaptureFunc:        func(r *http.Request) bool { return false },
+		responseCaptureFunc:       func(r *http.Request, status int) bool { return false },
 	}
 )
 
 type options struct {
 	levelFunc                 CodeToLevel
 	levelForConnectivityError logrus.Level
+	requestCaptureFunc        func(r *http.Request) bool
+	responseCaptureFunc       func(r *http.Request, status int) bool
 }
 
 func evaluateOptions(opts []Option) *options {
@@ -48,7 +52,7 @@ func evaluateMiddlewareOpts(opts []Option) *options {
 
 type Option func(*options)
 
-// CodeToLevel function defines the mapping between gRPC return codes and interceptor log level.
+// CodeToLevel user functions define the mapping between HTTP status codes and logrus log levels.
 type CodeToLevel func(httpStatusCode int) logrus.Level
 
 // WithLevels customizes the function that maps HTTP client or server side status codes to log levels.
@@ -65,6 +69,37 @@ func WithLevels(f CodeToLevel) Option {
 func WithConnectivityErrorLevel(level logrus.Level) Option {
 	return func(o *options) {
 		o.levelForConnectivityError = level
+	}
+}
+
+// WithRequestBodyCapture enables recording of request body pre-handling/pre-call.
+//
+// The body will be recorded as a separate log message. Body of `application/json` will be captured as
+// http.request.body_json (in structured JSON form) and others will be captured as http.request.body_raw logrus field
+// (raw base64-encoded value).
+//
+// For tripperware, only requests with Body of type `bytes.Buffer`, `strings.Reader`, `bytes.Buffer`, or with
+// a specified `GetBody` function will be captured.
+//
+// For middleware, only requests with a set Content-Length will be captured, with no streaming or chunk encoding supported.
+//
+// This option creates a copy of the body per request, so please use with care.
+func WithRequestBodyCapture(deciderFunc func(r *http.Request) bool) Option {
+	return func(o *options) {
+		o.requestCaptureFunc = deciderFunc
+	}
+}
+
+// WithResponseBodyCapture enables recording of response body post-handling/post-call.
+//
+// The body will be recorded as a separate log message. Body of `application/json` will be captured as
+// http.response.body_json (in structured JSON form) and others will be captured as http.response.body_raw logrus field
+// (raw base64-encoded value).
+//
+// Only responses with Content-Length will be captured, with non-default Transfer-Encoding not being supported.
+func WithResponseBodyCapture(deciderFunc func(r *http.Request, status int) bool) Option {
+	return func(o *options) {
+		o.responseCaptureFunc = deciderFunc
 	}
 }
 

--- a/logging/logrus/shared_test.go
+++ b/logging/logrus/shared_test.go
@@ -1,0 +1,139 @@
+package http_logrus_test
+
+import (
+	"net/http"
+	"net/http/httputil"
+	"strings"
+	"testing"
+
+	"bytes"
+	"encoding/json"
+	"io"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/mwitkow/go-httpwares/logging/logrus"
+	"github.com/mwitkow/go-httpwares/tags"
+	"github.com/mwitkow/go-httpwares/testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testCodeImATeapot = http.StatusTeapot
+)
+
+func requestCaptureDeciderForTest(req *http.Request) bool {
+	return strings.HasPrefix(req.URL.Path, "/capture/request/")
+}
+
+func responseCaptureDeciderForTest(req *http.Request, code int) bool {
+	return strings.HasPrefix(req.URL.Path, "/capture/request/")
+}
+
+type loggingHandler struct {
+	*testing.T
+}
+
+func (a *loggingHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
+	assert.NotNil(a.T, http_logrus.Extract(req), "handlers must have access to the loggermust have ")
+	http_ctxtags.ExtractInbound(req).Set("custom_tags.string", "something").Set("custom_tags.int", 1337)
+	http_logrus.Extract(req).Warningf("handler_log")
+	httpwares_testing.PingBackHandler(httpwares_testing.DefaultPingBackStatusCode).ServeHTTP(resp, req)
+}
+
+func handlerForTestingOfCaptures(t *testing.T) http.Handler {
+	m := http.NewServeMux()
+	m.HandleFunc("/capture/request/chunked", handlerChunked())
+	m.HandleFunc("/capture/request/plain", handlerPlainText())
+	m.Handle("/", &loggingHandler{t})
+	return m
+}
+
+func handlerPlainText() http.HandlerFunc {
+	return func(resp http.ResponseWriter, req *http.Request) {
+		resp.Header().Set("content-type", "text/html")
+		resp.WriteHeader(200)
+		resp.Write([]byte(`<body><head>Nothing</head></body>`))
+	}
+}
+
+func handlerChunked() http.HandlerFunc {
+	return func(resp http.ResponseWriter, req *http.Request) {
+		resp.Header().Set("content-type", "text/plain")
+		resp.Header().Set("Transfer-Encoding", "chunked")
+		resp.WriteHeader(200)
+		chunkedWriter := httputil.NewChunkedWriter(resp)
+		for i := 0; i < 100; i++ {
+			chunkedWriter.Write([]byte("value"))
+			resp.(http.Flusher).Flush()
+		}
+		chunkedWriter.Close()
+	}
+}
+
+type logrusBaseTestSuite struct {
+	*httpwares_testing.WaresTestSuite
+	buffer         *bytes.Buffer
+	threadedBuffer *httpwares_testing.MutexReadWriter
+	logger         *logrus.Logger
+}
+
+func newLogrusBaseTestSuite(t *testing.T) *logrusBaseTestSuite {
+	b := &bytes.Buffer{}
+	threadedBuffer := httpwares_testing.NewMutexReadWriter(b)
+	logger := logrus.New()
+	logger.Out = threadedBuffer
+	logger.Formatter = &logrus.JSONFormatter{DisableTimestamp: true}
+	s := &logrusBaseTestSuite{
+		logger:         logger,
+		buffer:         b,
+		threadedBuffer: threadedBuffer,
+		WaresTestSuite: &httpwares_testing.WaresTestSuite{
+			Handler: handlerForTestingOfCaptures(t),
+		},
+	}
+	return s
+}
+
+func (s *logrusBaseTestSuite) SetupTest() {
+	// Always delete all entries between tests.
+	s.threadedBuffer.Mutex.Lock()
+	s.buffer.Reset()
+	s.threadedBuffer.Mutex.Unlock()
+}
+
+func (s *logrusBaseTestSuite) getOutputJSONs() []string {
+	// So the final `handled` method may happen after the client completed the response. So wait here.
+	time.Sleep(15 * time.Millisecond)
+	ret := []string{}
+	dec := json.NewDecoder(s.threadedBuffer)
+	for {
+		var val map[string]json.RawMessage
+		err := dec.Decode(&val)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			s.T().Fatalf("failed decoding output from Logrus JSON: %v", err)
+		}
+		out, _ := json.MarshalIndent(val, "", "  ")
+		ret = append(ret, string(out))
+	}
+	return ret
+}
+
+func (s *logrusBaseTestSuite) makeSuccessfulRequestWithAssertions(req *http.Request, expectedLogMessages int, expectedKind string) []string {
+	client := s.NewClient()
+	newReq := req.WithContext(s.SimpleCtx())
+	_, err := client.Do(newReq)
+	require.NoError(s.T(), err, "call shouldn't fail")
+	msgs := s.getOutputJSONs()
+	require.Len(s.T(), msgs, expectedLogMessages, "this call should result in a different number of log statments")
+	for _, m := range msgs {
+		assert.Contains(s.T(), m, `"span.kind": "`+expectedKind+`"`, "all lines must contain indicator of being the right kind call")
+		assert.Contains(s.T(), m, `"http.host": "`+req.URL.Host+`"`, "all lines must contain http.host from http_ctxtags")
+		assert.Contains(s.T(), m, `"http.url.path": "`+req.URL.Path+`"`, "all lines must contain method name")
+	}
+	return msgs
+}

--- a/logging/logrus/tripperware.go
+++ b/logging/logrus/tripperware.go
@@ -7,12 +7,6 @@ import (
 	"net/http"
 	"time"
 
-	"bytes"
-	"encoding/base64"
-	"encoding/json"
-	"io/ioutil"
-	"strings"
-
 	"github.com/Sirupsen/logrus"
 	"github.com/mwitkow/go-httpwares"
 	"github.com/mwitkow/go-httpwares/tags"
@@ -27,93 +21,35 @@ func Tripperware(entry *logrus.Entry, opts ...Option) httpwares.Tripperware {
 		o := evaluateTripperwareOpts(opts)
 		return httpwares.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 			startTime := time.Now()
-			fields := logrus.Fields{
-				"system":                    SystemField,
-				"span.kind":                 "client",
-				"http.url.path":             req.URL.Path,
-				"http.request.length_bytes": req.ContentLength,
-			}
-			for k, v := range http_ctxtags.ExtractOutbound(req).Values() {
-				fields[k] = v
-			}
-			if o.requestCaptureFunc(req) {
-				if err := captureTripperwareRequestContent(req, entry.WithFields(fields)); err != nil {
-					logError(o, entry.WithFields(fields), err)
-					return nil, err // errors reading GetBody and other problems on client side
-				}
-			}
+			fields := newClientRequestFields(req)
 			resp, err := next.RoundTrip(req)
-			fields["http.time_ms"] = timeDiffToMilliseconds(startTime)
 			if err != nil {
-				logError(o, entry.WithFields(fields), err)
-				return nil, err
+				logError(o.levelForConnectivityError, entry.WithFields(fields), err)
+				return resp, err
 			}
+			fields["http.time_ms"] = timeDiffToMilliseconds(startTime)
 			fields["http.proto_major"] = resp.ProtoMajor
 			fields["http.response.length_bytes"] = resp.ContentLength
 			fields["http.status"] = resp.StatusCode
-			if o.responseCaptureFunc(req, resp.StatusCode) {
-				if err := captureTripperwareResponseContent(resp, entry.WithFields(fields)); err != nil {
-					logError(o, entry.WithFields(fields), err)
-					return nil, err
-				}
-			}
 			levelLogf(entry.WithFields(fields), o.levelFunc(resp.StatusCode), "request completed")
 			return resp, nil
 		})
 	}
 }
 
-func logError(o *options, e *logrus.Entry, err error) {
-	levelLogf(e, o.levelForConnectivityError, "request failed to execute, see err")
+func logError(level logrus.Level, e *logrus.Entry, err error) {
+	levelLogf(e.WithError(err), level, "request failed to execute, see err")
 }
 
-func headerIsJson(header http.Header) bool {
-	return strings.HasPrefix(strings.ToLower(header.Get("content-type")), "application/json")
-}
-
-func captureTripperwareRequestContent(req *http.Request, entry *logrus.Entry) error {
-	// All requests created with http.NewRequest will have a GetBody method set, even if the user created
-	// a body manually.
-	if req.GetBody == nil {
-		if req.Body != nil {
-			entry.Infof("request body capture skipped, missing GetBody method while Body set")
-		}
-		return nil
+func newClientRequestFields(req *http.Request) logrus.Fields {
+	fields := logrus.Fields{
+		"system":                    SystemField,
+		"span.kind":                 "client",
+		"http.url.path":             req.URL.Path,
+		"http.request.length_bytes": req.ContentLength,
 	}
-	bodyReader, err := req.GetBody()
-	if err != nil {
-		return err
+	for k, v := range http_ctxtags.ExtractOutbound(req).Values() {
+		fields[k] = v
 	}
-	content, err := ioutil.ReadAll(bodyReader)
-	if err != nil {
-		return err
-	}
-	if headerIsJson(req.Header) {
-		entry.WithField("http.request.body_json", json.RawMessage(content)).Info("request body captured in http.request.body_json field")
-	} else {
-		entry.WithField("http.request.body_raw", base64.StdEncoding.EncodeToString(content)).Info("request body captured in http.request.body_raw field")
-	}
-	return nil
-}
-
-func captureTripperwareResponseContent(resp *http.Response, entry *logrus.Entry) error {
-	if resp.ContentLength <= 0 {
-		// TODO(mwitkow): Deal with response.Uncompressed and gzip encoding (Content Length -1).
-		if resp.ContentLength != 0 {
-			entry.Infof("response body capture skipped, content length negative")
-		}
-		return nil
-	}
-	content, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return err // this is an error form the response reading, potentially a connection failure
-	}
-	// Make sure we give the Response back its body so the client can read it.
-	resp.Body = ioutil.NopCloser(bytes.NewReader(content))
-	if headerIsJson(resp.Header) {
-		entry.WithField("http.response.body_json", json.RawMessage(content)).Info("request body captured in http.response.body_json field")
-	} else {
-		entry.WithField("http.response.body_raw", base64.StdEncoding.EncodeToString(content)).Info("request body captured in http.response.body_raw field")
-	}
-	return nil
+	return fields
 }

--- a/logging/logrus/tripperware.go
+++ b/logging/logrus/tripperware.go
@@ -7,6 +7,12 @@ import (
 	"net/http"
 	"time"
 
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"io/ioutil"
+	"strings"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/mwitkow/go-httpwares"
 	"github.com/mwitkow/go-httpwares/tags"
@@ -21,31 +27,88 @@ func Tripperware(entry *logrus.Entry, opts ...Option) httpwares.Tripperware {
 		o := evaluateTripperwareOpts(opts)
 		return httpwares.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 			startTime := time.Now()
-			resp, err := next.RoundTrip(req)
 			fields := logrus.Fields{
 				"system":        SystemField,
 				"span.kind":     "client",
 				"http.url.path": req.URL.Path,
-				"http.time_ms":  timeDiffToMilliseconds(startTime),
 			}
 			for k, v := range http_ctxtags.ExtractOutbound(req).Values() {
 				fields[k] = v
 			}
-			level := logrus.DebugLevel
-			msg := "request completed"
-			if err != nil {
-				fields[logrus.ErrorKey] = err
-				level = o.levelForConnectivityError
-				msg = "request failed to execute, see err"
-			} else {
-				fields["http.proto_major"] = resp.ProtoMajor
-				fields["http.response_bytes"] = resp.ContentLength
-				fields["http.status"] = resp.StatusCode
-
-				level = o.levelFunc(resp.StatusCode)
+			if o.requestCaptureFunc(req) {
+				if err := captureTripperwareRequestContent(req, entry.WithFields(fields)); err != nil {
+					logError(o, entry.WithFields(fields), err)
+					return nil, err // errors reading GetBody and other problems on client side
+				}
 			}
-			levelLogf(entry.WithFields(fields), level, msg)
-			return resp, err
+			resp, err := next.RoundTrip(req)
+			fields["http.time_ms"] = timeDiffToMilliseconds(startTime)
+			if err != nil {
+				logError(o, entry.WithFields(fields), err)
+				return nil, err
+			}
+			fields["http.proto_major"] = resp.ProtoMajor
+			fields["http.response.length_bytes"] = resp.ContentLength
+			fields["http.status"] = resp.StatusCode
+			if o.responseCaptureFunc(req, resp.StatusCode) {
+				if err := captureTripperwareResponseContent(resp, entry.WithFields(fields)); err != nil {
+					logError(o, entry.WithFields(fields), err)
+					return nil, err
+				}
+			}
+			levelLogf(entry.WithFields(fields), o.levelFunc(resp.StatusCode), "request completed")
+			return resp, nil
 		})
 	}
+}
+
+func logError(o *options, e *logrus.Entry, err error) {
+	levelLogf(e, o.levelForConnectivityError, "request failed to execute, see err")
+}
+
+func captureTripperwareRequestContent(req *http.Request, entry *logrus.Entry) error {
+	// All requests created with http.NewRequest will have a GetBody method set, even if the user created
+	// a body manually.
+	if req.GetBody == nil {
+		if req.Body != nil {
+			entry.Infof("request body capture skipped, missing GetBody method while Body set")
+		}
+		return nil
+	}
+	bodyReader, err := req.GetBody()
+	if err != nil {
+		return err
+	}
+	content, err := ioutil.ReadAll(bodyReader)
+	if err != nil {
+		return err
+	}
+	if strings.HasPrefix(strings.ToLower(req.Header.Get("content-type")), "application/json") {
+		entry.WithField("http.request.body_json", json.RawMessage(content)).Info("request body captured in http.request.body_json field")
+	} else {
+		entry.WithField("http.request.body_raw", base64.StdEncoding.EncodeToString(content)).Info("request body captured in http.request.body_raw field")
+	}
+	return nil
+}
+
+func captureTripperwareResponseContent(resp *http.Response, entry *logrus.Entry) error {
+	if resp.ContentLength <= 0 {
+		// TODO(mwitkow): Deal with response.Uncompressed and gzip encoding (Content Length -1).
+		if resp.ContentLength != 0 {
+			entry.Infof("response body capture skipped, content length negative")
+		}
+		return nil
+	}
+	content, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err // this is an error form the response reading, potentially a connection failure
+	}
+	// Make sure we give the Response back its body so the client can read it.
+	resp.Body = ioutil.NopCloser(bytes.NewReader(content))
+	if strings.HasPrefix(strings.ToLower(resp.Header.Get("content-type")), "application/json") {
+		entry.WithField("http.response.body_json", json.RawMessage(content)).Info("request body captured in http.response.body_json field")
+	} else {
+		entry.WithField("http.response.body_raw", base64.StdEncoding.EncodeToString(content)).Info("request body captured in http.response.body_raw field")
+	}
+	return nil
 }

--- a/logging/logrus/tripperware.go
+++ b/logging/logrus/tripperware.go
@@ -67,6 +67,10 @@ func logError(o *options, e *logrus.Entry, err error) {
 	levelLogf(e, o.levelForConnectivityError, "request failed to execute, see err")
 }
 
+func headerIsJson(header http.Header) bool {
+	return strings.HasPrefix(strings.ToLower(header.Get("content-type")), "application/json")
+}
+
 func captureTripperwareRequestContent(req *http.Request, entry *logrus.Entry) error {
 	// All requests created with http.NewRequest will have a GetBody method set, even if the user created
 	// a body manually.
@@ -84,7 +88,7 @@ func captureTripperwareRequestContent(req *http.Request, entry *logrus.Entry) er
 	if err != nil {
 		return err
 	}
-	if strings.HasPrefix(strings.ToLower(req.Header.Get("content-type")), "application/json") {
+	if headerIsJson(req.Header) {
 		entry.WithField("http.request.body_json", json.RawMessage(content)).Info("request body captured in http.request.body_json field")
 	} else {
 		entry.WithField("http.request.body_raw", base64.StdEncoding.EncodeToString(content)).Info("request body captured in http.request.body_raw field")
@@ -106,7 +110,7 @@ func captureTripperwareResponseContent(resp *http.Response, entry *logrus.Entry)
 	}
 	// Make sure we give the Response back its body so the client can read it.
 	resp.Body = ioutil.NopCloser(bytes.NewReader(content))
-	if strings.HasPrefix(strings.ToLower(resp.Header.Get("content-type")), "application/json") {
+	if headerIsJson(resp.Header) {
 		entry.WithField("http.response.body_json", json.RawMessage(content)).Info("request body captured in http.response.body_json field")
 	} else {
 		entry.WithField("http.response.body_raw", base64.StdEncoding.EncodeToString(content)).Info("request body captured in http.response.body_raw field")

--- a/logging/logrus/tripperware.go
+++ b/logging/logrus/tripperware.go
@@ -28,9 +28,10 @@ func Tripperware(entry *logrus.Entry, opts ...Option) httpwares.Tripperware {
 		return httpwares.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 			startTime := time.Now()
 			fields := logrus.Fields{
-				"system":        SystemField,
-				"span.kind":     "client",
-				"http.url.path": req.URL.Path,
+				"system":                    SystemField,
+				"span.kind":                 "client",
+				"http.url.path":             req.URL.Path,
+				"http.request.length_bytes": req.ContentLength,
 			}
 			for k, v := range http_ctxtags.ExtractOutbound(req).Values() {
 				fields[k] = v

--- a/logging/logrus/tripperware_test.go
+++ b/logging/logrus/tripperware_test.go
@@ -4,15 +4,11 @@
 package http_logrus_test
 
 import (
-	"bytes"
 	"fmt"
-	"io"
 	"net/http"
 	"runtime"
 	"strings"
 	"testing"
-
-	"mime/multipart"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/mwitkow/go-httpwares"
@@ -100,75 +96,4 @@ func (s *logrusTripperwareSuite) TestSuccessfulCall_WithRemap() {
 		assert.Contains(s.T(), m, fmt.Sprintf(`"http.status": %d`, tcase.code), "all lines must contain method name")
 		assert.Contains(s.T(), m, fmt.Sprintf(`"level": "%s"`, tcase.level.String()), tcase.msg)
 	}
-}
-
-func (s *logrusTripperwareSuite) TestCapture_SimpleJSONBothWays() {
-	content := new(bytes.Buffer)
-	content.WriteString(`{"somekey": "some_value", "someint": 4}`)
-	req, _ := http.NewRequest("POST", "https://fakeaddress.fakeaddress.com/capture/request/json", content)
-	req.Header.Set("content-type", "application/JSON")
-	msgs := s.makeSuccessfulRequestWithAssertions(req, 3, "client")
-
-	reqMsg, respMsg, finalMsg := msgs[0], msgs[1], msgs[2]
-	assert.Contains(s.T(), reqMsg, `"level": "info"`, "request captures should be logged as info")
-	assert.Contains(s.T(), respMsg, `"level": "info"`, "response captures should be logged as info")
-	assert.Contains(s.T(), reqMsg, `"http.request.body_json": {`, "request capture should log messages as structued json")
-	assert.Contains(s.T(), respMsg, `"http.response.body_json": {`, "response capture should log messages as structued json")
-	assert.Contains(s.T(), respMsg, `"http.time_ms":`, "interceptor log statement should contain execution time")
-	assert.Contains(s.T(), finalMsg, `"http.time_ms":`, "interceptor log statement should contain execution time")
-}
-
-func (s *logrusTripperwareSuite) TestCapture_PlainTextBothWays() {
-	content := new(bytes.Buffer)
-	content.WriteString(`Lorem Ipsum, who cares?`)
-	req, _ := http.NewRequest("POST", "https://fakeaddress.fakeaddress.com/capture/request/plain", content)
-	req.Header.Set("content-type", "text/plain")
-	msgs := s.makeSuccessfulRequestWithAssertions(req, 3, "client")
-
-	reqMsg, respMsg, finalMsg := msgs[0], msgs[1], msgs[2]
-	assert.Contains(s.T(), reqMsg, `"level": "info"`, "request captures should be logged as info")
-	assert.Contains(s.T(), respMsg, `"level": "info"`, "response captures should be logged as info")
-	assert.Contains(s.T(), reqMsg, `"http.request.body_raw": "`, "request capture should log messages as strings")
-	assert.Contains(s.T(), respMsg, `"http.response.body_raw": "`, "response capture should log messages as strings")
-	assert.Contains(s.T(), respMsg, `"http.time_ms":`, "interceptor log statement should contain execution time")
-	assert.Contains(s.T(), finalMsg, `"http.time_ms":`, "interceptor log statement should contain execution time")
-}
-
-func (s *logrusTripperwareSuite) TestCapture_StreamFileUp() {
-	// Make a request that simulates a file upload.
-	reader, writer := io.Pipe()
-	multipartContent := multipart.NewWriter(writer)
-	go func() {
-		mimeWriter, _ := multipartContent.CreateFormFile("somefield", "filename.txt")
-		for i := 0; i < 10; i++ {
-			mimeWriter.Write([]byte("something\n"))
-		}
-		multipartContent.Close()
-		writer.Close()
-	}()
-
-	req, _ := http.NewRequest("POST", "https://fakeaddress.fakeaddress.com/capture/request/json", reader)
-	req.Header.Set("content-type", multipartContent.FormDataContentType())
-	msgs := s.makeSuccessfulRequestWithAssertions(req, 4, "client")
-
-	reqMsg, finalMsg := msgs[0], msgs[2]
-	assert.Contains(s.T(), reqMsg, `"level": "info"`, "request captures should be logged as info")
-	assert.Contains(s.T(), reqMsg, `request body capture skipped, missing GetBody method while Body set`, "request should log a helpful error")
-	assert.Contains(s.T(), finalMsg, `"http.time_ms":`, "interceptor log statement should contain execution time")
-}
-
-func (s *logrusTripperwareSuite) TestCapture_ChunkResponse() {
-	content := new(bytes.Buffer)
-	content.WriteString(`{"somekey": "some_value", "someint": 4}`)
-	req, _ := http.NewRequest("POST", "https://fakeaddress.fakeaddress.com/capture/request/chunked", content)
-	req.Header.Set("content-type", "application/JSON")
-	msgs := s.makeSuccessfulRequestWithAssertions(req, 3, "client")
-	respMsg, finalMsg := msgs[1], msgs[2]
-	assert.Contains(s.T(), respMsg, `"level": "info"`, "response captures should be logged as info")
-	assert.Contains(s.T(), respMsg, `response body capture skipped, content length negative`, "response capture should log a helpful message")
-	assert.Contains(s.T(), respMsg, `"http.time_ms":`, "interceptor log statement should contain execution time")
-	assert.Contains(s.T(), finalMsg, `"http.time_ms":`, "interceptor log statement should contain execution time")
-}
-
-func (s *logrusTripperwareSuite) assertCommonLogLinesForRequest(req *http.Request) {
 }

--- a/logging/logrus/tripperware_test.go
+++ b/logging/logrus/tripperware_test.go
@@ -36,11 +36,11 @@ func customTripperwareCodeToLevel(statusCode int) logrus.Level {
 	return level
 }
 
-func tripperRequestCaptureDeciderForTest(req *http.Request) bool {
+func requestCaptureDeciderForTest(req *http.Request) bool {
 	return strings.HasPrefix(req.URL.Path, "/capture/request/")
 }
 
-func tripperResponseCaptureDeciderForTest(req *http.Request, code int) bool {
+func responseCaptureDeciderForTest(req *http.Request, code int) bool {
 	return strings.HasPrefix(req.URL.Path, "/capture/request/")
 }
 
@@ -95,8 +95,8 @@ func TestLogrusTripperwareSuite(t *testing.T) {
 				http_logrus.Tripperware(
 					logrus.NewEntry(log),
 					http_logrus.WithLevels(customTripperwareCodeToLevel),
-					http_logrus.WithRequestBodyCapture(tripperRequestCaptureDeciderForTest),
-					http_logrus.WithResponseBodyCapture(tripperResponseCaptureDeciderForTest),
+					http_logrus.WithRequestBodyCapture(requestCaptureDeciderForTest),
+					http_logrus.WithResponseBodyCapture(responseCaptureDeciderForTest),
 				),
 			},
 		},
@@ -132,7 +132,7 @@ func (s *LogrusTripperwareSuite) getOutputJSONs() []string {
 	return ret
 }
 
-func (s *LogrusTripperwareSuite) xTestSuccessfulCall() {
+func (s *LogrusTripperwareSuite) TestSuccessfulCall() {
 	client := s.NewClient() // client always dials localhost.
 	req, _ := http.NewRequest("GET", "https://fakeaddress.fakeaddress.com/someurl", nil)
 	req = req.WithContext(s.SimpleCtx())
@@ -149,7 +149,7 @@ func (s *LogrusTripperwareSuite) xTestSuccessfulCall() {
 	assert.Contains(s.T(), m, `"http.time_ms":`, "interceptor log statement should contain execution time")
 }
 
-func (s *LogrusTripperwareSuite) xTestSuccessfulCall_WithRemap() {
+func (s *LogrusTripperwareSuite) TestSuccessfulCall_WithRemap() {
 	for _, tcase := range []struct {
 		code  int
 		level logrus.Level
@@ -192,7 +192,7 @@ func (s *LogrusTripperwareSuite) xTestSuccessfulCall_WithRemap() {
 	}
 }
 
-func (s *LogrusTripperwareSuite) xTestCapture_SimpleJSONBothWays() {
+func (s *LogrusTripperwareSuite) TestCapture_SimpleJSONBothWays() {
 	client := s.NewClient() // client always dials localhost.
 	content := new(bytes.Buffer)
 	content.WriteString(`{"somekey": "some_value", "someint": 4}`)
@@ -221,7 +221,7 @@ func (s *LogrusTripperwareSuite) xTestCapture_SimpleJSONBothWays() {
 	assert.Contains(s.T(), finalMsg, `"http.time_ms":`, "interceptor log statement should contain execution time")
 }
 
-func (s *LogrusTripperwareSuite) xTestCapture_PlainTextBothWays() {
+func (s *LogrusTripperwareSuite) TestCapture_PlainTextBothWays() {
 	client := s.NewClient() // client always dials localhost.
 	content := new(bytes.Buffer)
 	content.WriteString(`Lorem Ipsum, who cares?`)
@@ -247,7 +247,7 @@ func (s *LogrusTripperwareSuite) xTestCapture_PlainTextBothWays() {
 	assert.Contains(s.T(), finalMsg, `"http.time_ms":`, "interceptor log statement should contain execution time")
 }
 
-func (s *LogrusTripperwareSuite) xTestCapture_StreamFileUp() {
+func (s *LogrusTripperwareSuite) TestCapture_StreamFileUp() {
 	client := s.NewClient() // client always dials localhost.
 	reader, writer := io.Pipe()
 	multipartContent := multipart.NewWriter(writer)
@@ -298,7 +298,6 @@ func (s *LogrusTripperwareSuite) TestCapture_ChunkResponse() {
 		assert.Contains(s.T(), m, `"http.url.path": "/capture/request/chunked"`, "all lines must contain method name")
 	}
 	respMsg, finalMsg := msgs[1], msgs[2]
-	s.T().Log(respMsg)
 	assert.Contains(s.T(), respMsg, `"level": "info"`, "response captures should be logged as info")
 	assert.Contains(s.T(), respMsg, `response body capture skipped, content length negative`, "response capture should log a helpful message")
 	assert.Contains(s.T(), respMsg, `"http.time_ms":`, "interceptor log statement should contain execution time")

--- a/logging/logrus/tripperware_test.go
+++ b/logging/logrus/tripperware_test.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"testing"
 
+	"net/http/httputil"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/mwitkow/go-httpwares"
 	"github.com/mwitkow/go-httpwares/logging/logrus"
@@ -32,6 +34,41 @@ func customTripperwareCodeToLevel(statusCode int) logrus.Level {
 	return level
 }
 
+func tripperRequestCaptureDeciderForTest(req *http.Request) bool {
+	return strings.HasPrefix(req.URL.Path, "/capture/request/")
+}
+
+func tripperResponseCaptureDeciderForTest(req *http.Request, code int) bool {
+	return strings.HasPrefix(req.URL.Path, "/capture/request/")
+}
+
+func handlerForTestingOfCaptures(t *testing.T) http.Handler {
+	m := http.NewServeMux()
+	m.HandleFunc("/capture/request/chunked", handlerChunked())
+	m.HandleFunc("/capture/request/plain", handlerPlainText())
+	m.Handle("/", &loggingHandler{t})
+	return m
+}
+
+func handlerPlainText() http.HandlerFunc {
+	return func(resp http.ResponseWriter, req *http.Request) {
+		resp.Header().Set("content-type", "text/html")
+		resp.WriteHeader(200)
+		resp.Write([]byte(`<body><head>Nothing</head></body>`))
+	}
+}
+
+func handlerChunked() http.HandlerFunc {
+	return func(resp http.ResponseWriter, req *http.Request) {
+		resp.Header().Set("content-type", "text/plain")
+		resp.WriteHeader(200)
+		chunkedWriter := httputil.NewChunkedWriter(resp)
+		chunkedWriter.Write([]byte("value one"))
+		chunkedWriter.Write([]byte("value two"))
+		chunkedWriter.Close()
+	}
+}
+
 func TestLogrusTripperwareSuite(t *testing.T) {
 	if strings.HasPrefix(runtime.Version(), "go1.7") {
 		t.Skipf("Skipping due to json.RawMessage incompatibility with go1.7")
@@ -42,14 +79,20 @@ func TestLogrusTripperwareSuite(t *testing.T) {
 	log.Out = b
 	log.Level = logrus.DebugLevel
 	log.Formatter = &logrus.JSONFormatter{DisableTimestamp: true}
+
 	s := &LogrusTripperwareSuite{
 		log:    logrus.NewEntry(log),
 		buffer: b,
 		WaresTestSuite: &httpwares_testing.WaresTestSuite{
-			Handler: &loggingHandler{t},
+			Handler: handlerForTestingOfCaptures(t),
 			ClientTripperware: httpwares.TripperwareChain{
 				http_ctxtags.Tripperware(),
-				http_logrus.Tripperware(logrus.NewEntry(log), http_logrus.WithLevels(customTripperwareCodeToLevel)),
+				http_logrus.Tripperware(
+					logrus.NewEntry(log),
+					http_logrus.WithLevels(customTripperwareCodeToLevel),
+					http_logrus.WithRequestBodyCapture(tripperRequestCaptureDeciderForTest),
+					http_logrus.WithResponseBodyCapture(tripperResponseCaptureDeciderForTest),
+				),
 			},
 		},
 	}
@@ -93,7 +136,6 @@ func (s *LogrusTripperwareSuite) TestSuccessfulCall() {
 	msgs := s.getOutputJSONs()
 	require.Len(s.T(), msgs, 1, "one log statements should be logged")
 	m := msgs[0]
-	s.T().Log(m)
 	assert.Contains(s.T(), m, `"span.kind": "client"`, "all lines must contain indicator of being a client call")
 	assert.Contains(s.T(), m, `"http.host": "fakeaddress.fakeaddress.com"`, "all lines must contain http.host from http_ctxtags")
 	assert.Contains(s.T(), m, `"http.url.path": "/someurl"`, "all lines must contain method name")
@@ -143,4 +185,59 @@ func (s *LogrusTripperwareSuite) TestSuccessfulCall_WithRemap() {
 		assert.Contains(s.T(), m, fmt.Sprintf(`"http.status": %d`, tcase.code), "all lines must contain method name")
 		assert.Contains(s.T(), m, fmt.Sprintf(`"level": "%s"`, tcase.level.String()), tcase.msg)
 	}
+}
+
+func (s *LogrusTripperwareSuite) TestCapture_SimpleJSONBothWays() {
+	client := s.NewClient() // client always dials localhost.
+	content := new(bytes.Buffer)
+	content.WriteString(`{"somekey": "some_value", "someint": 4}`)
+	req, _ := http.NewRequest("POST", "https://fakeaddress.fakeaddress.com/capture/request/json", content)
+	req = req.WithContext(s.SimpleCtx())
+	req.Header.Set("content-type", "application/JSON")
+	resp, err := client.Do(req)
+	require.NoError(s.T(), err, "call shouldn't fail")
+	pingBack, err := httpwares_testing.DecodePingBack(resp)
+	require.NoError(s.T(), err, "decoding pingback response must not fail, otherwise we change the behaviour of the client")
+	assert.NotEmpty(s.T(), "application/JSON", pingBack.Headers["content-type"], "the content must be preserved")
+
+	msgs := s.getOutputJSONs()
+	require.Len(s.T(), msgs, 3, "three log statements should be logged: captured req, captured resp, and final one")
+	for _, m := range msgs {
+		assert.Contains(s.T(), m, `"span.kind": "client"`, "all lines must contain indicator of being a client call")
+		assert.Contains(s.T(), m, `"http.host": "fakeaddress.fakeaddress.com"`, "all lines must contain http.host from http_ctxtags")
+		assert.Contains(s.T(), m, `"http.url.path": "/capture/request/json"`, "all lines must contain method name")
+	}
+	reqMsg, respMsg, finalMsg := msgs[0], msgs[1], msgs[2]
+	assert.Contains(s.T(), reqMsg, `"level": "info"`, "request captures should be logged as info")
+	assert.Contains(s.T(), respMsg, `"level": "info"`, "response captures should be logged as info")
+	assert.Contains(s.T(), reqMsg, `"http.request.body_json": {`, "request capture should log messages as structued json")
+	assert.Contains(s.T(), respMsg, `"http.response.body_json": {`, "response capture should log messages as structued json")
+	assert.Contains(s.T(), respMsg, `"http.time_ms":`, "interceptor log statement should contain execution time")
+	assert.Contains(s.T(), finalMsg, `"http.time_ms":`, "interceptor log statement should contain execution time")
+}
+
+func (s *LogrusTripperwareSuite) TestCapture_PlainTextBothWays() {
+	client := s.NewClient() // client always dials localhost.
+	content := new(bytes.Buffer)
+	content.WriteString(`Lorem Ipsum, who cares?`)
+	req, _ := http.NewRequest("POST", "https://fakeaddress.fakeaddress.com/capture/request/plain", content)
+	req = req.WithContext(s.SimpleCtx())
+	req.Header.Set("content-type", "text/plain")
+	_, err := client.Do(req)
+	require.NoError(s.T(), err, "call shouldn't fail")
+	msgs := s.getOutputJSONs()
+	require.Len(s.T(), msgs, 3, "three log statements should be logged: captured req, captured resp, and final one")
+	for _, m := range msgs {
+		assert.Contains(s.T(), m, `"span.kind": "client"`, "all lines must contain indicator of being a client call")
+		assert.Contains(s.T(), m, `"http.host": "fakeaddress.fakeaddress.com"`, "all lines must contain http.host from http_ctxtags")
+		assert.Contains(s.T(), m, `"http.url.path": "/capture/request/plain"`, "all lines must contain method name")
+	}
+	reqMsg, respMsg, finalMsg := msgs[0], msgs[1], msgs[2]
+
+	assert.Contains(s.T(), reqMsg, `"level": "info"`, "request captures should be logged as info")
+	assert.Contains(s.T(), respMsg, `"level": "info"`, "response captures should be logged as info")
+	assert.Contains(s.T(), reqMsg, `"http.request.body_raw": "`, "request capture should log messages as strings")
+	assert.Contains(s.T(), respMsg, `"http.response.body_raw": "`, "response capture should log messages as strings")
+	assert.Contains(s.T(), respMsg, `"http.time_ms":`, "interceptor log statement should contain execution time")
+	assert.Contains(s.T(), finalMsg, `"http.time_ms":`, "interceptor log statement should contain execution time")
 }

--- a/logging/options.go
+++ b/logging/options.go
@@ -1,0 +1,9 @@
+package http_logging
+
+import (
+	"net/http"
+)
+
+// ContentCaptureDeciderFunc is a user-provide function that decides whether the given request-response should be captured
+// for logging purposes.
+type ContentCaptureDeciderFunc func(req *http.Request) bool

--- a/testing/mutex_rw.go
+++ b/testing/mutex_rw.go
@@ -1,0 +1,31 @@
+package httpwares_testing
+
+import (
+	"io"
+	"sync"
+)
+
+// MutexReadWriter is a io.ReadWriter that can be read and worked on from multiple go routines.
+type MutexReadWriter struct {
+	sync.Mutex
+	rw io.ReadWriter
+}
+
+// NewMutexReadWriter creates a new thread-safe io.ReadWriter.
+func NewMutexReadWriter(rw io.ReadWriter) *MutexReadWriter {
+	return &MutexReadWriter{rw: rw}
+}
+
+// Write implements the io.Writer interface.
+func (gb *MutexReadWriter) Write(p []byte) (int, error) {
+	gb.Lock()
+	defer gb.Unlock()
+	return gb.rw.Write(p)
+}
+
+// Read implements the io.Reader interface.
+func (gb *MutexReadWriter) Read(p []byte) (int, error) {
+	gb.Lock()
+	defer gb.Unlock()
+	return gb.rw.Read(p)
+}

--- a/testing/pingback.go
+++ b/testing/pingback.go
@@ -43,3 +43,12 @@ func PingBackHandler(retCode int) http.HandlerFunc {
 		json.NewEncoder(resp).Encode(respJs)
 	}
 }
+
+// DecodePingBack returns a parsed PingBackResponse for assertion purposes.
+func DecodePingBack(resp *http.Response) (*PingBackResponse, error) {
+	val := &PingBackResponse{}
+	if err := json.NewDecoder(resp.Body).Decode(val); err != nil {
+		return nil, err
+	}
+	return val, nil
+}

--- a/testing/wares_suite.go
+++ b/testing/wares_suite.go
@@ -106,7 +106,7 @@ func (s *WaresTestSuite) ServerAddr() string {
 }
 
 func (s *WaresTestSuite) SimpleCtx() context.Context {
-	ctx, _ := context.WithTimeout(context.TODO(), 1*time.Second)
+	ctx, _ := context.WithTimeout(context.TODO(), 15000*time.Second)
 	return ctx
 }
 

--- a/wrapped_responsewriter.go
+++ b/wrapped_responsewriter.go
@@ -64,7 +64,7 @@ func (w *wrappedResponseWriter) WriteHeader(code int) {
 	}
 }
 func (w *wrappedResponseWriter) Write(buf []byte) (int, error) {
-	w.WriteHeader(http.StatusOK)
+	w.WriteHeader(http.StatusOK) // double writes are ignored.
 	n, err := w.ResponseWriter.Write(buf)
 	for _, o := range w.observerWrite {
 		o(w, buf, n, err)


### PR DESCRIPTION
This adds request and response body logging inside `http_logrus`. Both client-side (Tripperware) and server-side (Middleware) are supported.

Special handling is performed for `application/json` so that the JSON payload is logged in structure form. Other "fixed-size" (non-chuhked, non gzipped, non multipart) responses/requests are logged as `base64`-encoded payloads.