### PR TITLE
Moved to routePath for chi tags, after change on their context.

### DIFF
--- a/tags/DOC.md
+++ b/tags/DOC.md
@@ -41,6 +41,7 @@ Tags fields are typed, and shallow and should follow the OpenTracing semantics c
 - [github.com/pressly/chi](https://godoc.org/github.com/pressly/chi)
 
 ## <a name="pkg-index">Index</a>
+
 * [Constants](#pkg-constants)
 * [Variables](#pkg-variables)
 * [func ChiRouteTagExtractor(req \*http.Request) map[string]interface{}](#ChiRouteTagExtractor)

--- a/tags/DOC.md
+++ b/tags/DOC.md
@@ -36,7 +36,6 @@ Tags fields are typed, and shallow and should follow the OpenTracing semantics c
 <a href="https://github.com/opentracing/specification/blob/master/semantic_conventions.md">https://github.com/opentracing/specification/blob/master/semantic_conventions.md</a>
 
 ## <a name="pkg-imports">Imported Packages</a>
-
 - [github.com/mwitkow/go-httpwares](./..)
 - [github.com/pressly/chi](https://godoc.org/github.com/pressly/chi)
 

--- a/tags/chi.go
+++ b/tags/chi.go
@@ -15,7 +15,7 @@ import (
 func ChiRouteTagExtractor(req *http.Request) map[string]interface{} {
 	if routeCtx, ok := req.Context().Value(chi.RouteCtxKey).(*chi.Context); ok {
 		val := map[string]interface{}{
-			TagForHandlerName: routeCtx.RoutePattern,
+			TagForHandlerName: routeCtx.RoutePath,
 		}
 		// TODO(bplotka): Find a way to obtain params from chi routeCtx.URLParams (routeParams struct).
 		// Internal keys & values are no longer public, you can only ask for known keys


### PR DESCRIPTION
Commit that broke things: https://github.com/go-chi/chi/commit/49e7138cabd9e374dcbf1a3b56d3ba4a459763e2#diff-05a3aa0ab9e5687ff167e0ef3ae4c5a6

TODO: Vendoring ):

Signed-off-by: Bartek Plotka <bwplotka@gmail.com>