### PR TITLE
Move Chi tags into separate package.

### DIFF
--- a/tags/chi/chi.go
+++ b/tags/chi/chi.go
@@ -1,12 +1,13 @@
 // Copyright 2017 Michal Witkowski. All Rights Reserved.
 // See LICENSE for licensing terms.
 
-package http_ctxtags
+package http_chitags
 
 import (
 	"net/http"
 
 	"github.com/pressly/chi"
+	"github.com/mwitkow/go-httpwares/tags"
 )
 
 // ChiRouteTagExtractor extracts chi router information and puts them into tags.
@@ -15,7 +16,7 @@ import (
 func ChiRouteTagExtractor(req *http.Request) map[string]interface{} {
 	if routeCtx, ok := req.Context().Value(chi.RouteCtxKey).(*chi.Context); ok {
 		val := map[string]interface{}{
-			TagForHandlerName: routeCtx.RoutePath,
+			http_ctxtags.TagForHandlerName: routeCtx.RoutePath,
 		}
 		// TODO(bplotka): Find a way to obtain params from chi routeCtx.URLParams (routeParams struct).
 		// Internal keys & values are no longer public, you can only ask for known keys

--- a/tags/integration_test.go
+++ b/tags/integration_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/mwitkow/go-httpwares"
 	"github.com/mwitkow/go-httpwares/tags"
+	"github.com/mwitkow/go-httpwares/tags/chi"
 	"github.com/mwitkow/go-httpwares/testing"
 	"github.com/pressly/chi"
 	"github.com/stretchr/testify/assert"
@@ -34,7 +35,7 @@ func TestTaggingSuite(t *testing.T) {
 	chiRouter.Use(
 		http_ctxtags.Middleware(
 			"someservice",
-			http_ctxtags.WithTagExtractor(http_ctxtags.ChiRouteTagExtractor),
+			http_ctxtags.WithTagExtractor(http_chitags.ChiRouteTagExtractor),
 		))
 	chiRouter.Mount("/", &assertingHandler{T: t, serviceName: "someservice"})
 	// This route will check whether the HandlerName passes the right metadata.


### PR DESCRIPTION
Allow users to avoid the Chi dependency if they want to make use of the debug package but don't use Chi.