### PR TITLE
Use a single line when tracing maps (headers, tags).

### DIFF
--- a/tracing/debug/DOC.md
+++ b/tracing/debug/DOC.md
@@ -38,7 +38,7 @@ func DefaultIsStatusCodeAnError(statusCode int) bool
 ```
 DefaultIsStatusCodeAnError defines a function that says whether a given request is an error based on a code.
 
-## <a name="Middleware">func</a> [Middleware](./middleware.go#L19)
+## <a name="Middleware">func</a> [Middleware](./middleware.go#L18)
 ``` go
 func Middleware(opts ...Option) httpwares.Middleware
 ```
@@ -46,7 +46,7 @@ Middleware returns a http.Handler middleware that writes inbound requests to /de
 
 The data logged will be: request headers, request ctxtags, response headers and response length.
 
-## <a name="Tripperware">func</a> [Tripperware](./tripperware.go#L18)
+## <a name="Tripperware">func</a> [Tripperware](./tripperware.go#L23)
 ``` go
 func Tripperware(opts ...Option) httpwares.Tripperware
 ```


### PR DESCRIPTION
Only about 10 request trace entries are kept by default. Merging headers
and tags into one entry each allows other entries to appear in the log.